### PR TITLE
Invert return value of StateIdle()

### DIFF
--- a/SoftIIC/src/SoftIIC.cpp
+++ b/SoftIIC/src/SoftIIC.cpp
@@ -376,7 +376,7 @@ uint8_t SoftIIC::wait_until_bus_is_idle(){
 		while(1){
 			SoftIIC::bus_read();
 			if(SoftIIC::StateStop()){return RETVAL_SUCCESS; }
-			if((SoftIIC::StateIdle())!=0){SoftIIC::TimerClearMatch(); }
+			if(!(SoftIIC::StateIdle())){SoftIIC::TimerClearMatch(); }
 			if(SoftIIC::TimerElapsed()) {return RETVAL_SUCCESS;}	
 		}
 	}else {
@@ -389,7 +389,7 @@ uint8_t SoftIIC::wait_until_bus_is_idle(){
 		while(num_half_clocks_remaining>0){	
 			while((SoftIIC::TimerElapsed())==0) {		
 				SoftIIC::bus_read();
-				if((SoftIIC::StateIdle())!=0){return RETVAL_PROTOCOL_FAILURE; }		
+				if(!(SoftIIC::StateIdle())){return RETVAL_PROTOCOL_FAILURE; }		
 			}
 			num_half_clocks_remaining--;
 		}


### PR DESCRIPTION
Though I see that development of the library halted few years ago, I am currently working on the fork, which is to implement stable multimaster support.  Don't know how far will this intention go, however now I'm dealing with some suspicious parts of your code. 

This patch fixes supposedly erroneous treatment of StateIdle()-s function return value. As far as I am concerned, it returns nonzero value if the bus is in the idle state(both SCL and SDA remain high), and since it is a normal case in single-master setup, your piece of code returns RETVAL_PROTOCOL_FAILURE immediately, which is, according to comments, is not intended. And because return value of wait_until_bus_is_idle() is not checked at all, this issue remains unnoticed.

In case multimaster support is enabled and there is actually only one master on bus(so that bus never goes into stop state), it seems that master is doomed to clear timer match flag just before checking it till eternity. However, I didn't actually check this scenario, because there seem to be some other serious issues with multimaster support.

Thank you.